### PR TITLE
Fix: return iCal format instead of JSON

### DIFF
--- a/api/[region].js
+++ b/api/[region].js
@@ -63,5 +63,5 @@ export default async (req, res) => {
     res.setHeader("Content-Disposition", `attachment; filename="regio-${region}.ics"`);
     res.setHeader("Cache-Control", `max-age=0,s-maxage=${ttl}, stale-while-revalidate=86400`); // 1 week
 
-    res.end(JSON.stringify(regionCal));
+    res.end(regionCal.toString());
 }


### PR DESCRIPTION
Deze PR lost het probleem op waarbij de API JSON retourneert in plaats van iCal formaat.

### Wat er veranderd is
- `api/[region].js` regel 66: `JSON.stringify(regionCal)` → `regionCal.toString()`

### Waarom
De API had de juiste headers ingesteld (`Content-Type: text/calendar`), maar gaf JSON terug in plaats van een geldig iCal bestand. Hierdoor kon het .ics bestand niet geïmporteerd worden in agenda applicaties.

### Resultaat
De API retourneert nu een correct iCal/ICS bestand dat geïmporteerd kan worden in agenda apps.

Fixes #23